### PR TITLE
Xygeni-Bumper - django from 1.2 to 1.4.11

### DIFF
--- a/tests/sca_package_2/examples/requirements.txt
+++ b/tests/sca_package_2/examples/requirements.txt
@@ -1,4 +1,4 @@
 # checkov:skip=CVE-2016-6186: ignore it
-django==1.2
+django==1.4.11
 flask==0.6
 requests==2.26.0


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps django:1.2 to 1.4.11 
### 🔍 Vulnerability Details 

- **Component:** django 
- **Fixed Version:** 1.4.11 
### 📝 Description 

CVE-2014-0474 The (1) FilePathField, (2) GenericIPAddressField, and (3) IPAddressField model field classes in Django before 1.4.11, 1.5.x before 1.5.6, 1.6.x before 1.6.3, and 1.7.x before 1.7 beta 2 do not properly perform type conversion, which allows remote attackers to have unspecified impact and vectors, related to "MySQL typecasting." 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2014-0474 



